### PR TITLE
Switch to trusty as precise is going to be EOL in a few days

### DIFF
--- a/recipes/meta/Bluefish.yml
+++ b/recipes/meta/Bluefish.yml
@@ -2,8 +2,8 @@ app: Bluefish
 union: true
 
 ingredients:
-  dist: precise
+  dist: trusty
   sources:
-    - deb http://us.archive.ubuntu.com/ubuntu/ precise main universe
+    - deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe
   ppas:
     - klaus-vormweg/bluefish-gtk2

--- a/recipes/meta/Devhelp.yml
+++ b/recipes/meta/Devhelp.yml
@@ -2,9 +2,9 @@ app: Devhelp
 union: true
 
 ingredients:
-  dist: precise
+  dist: trusty
   sources:
-    - deb http://us.archive.ubuntu.com/ubuntu/ precise main universe
+    - deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe
   packages:
     - devhelp
     - libgtk2.0-doc

--- a/recipes/meta/Go-For-It.yml
+++ b/recipes/meta/Go-For-It.yml
@@ -2,9 +2,9 @@ app: Go-For-It
 union: true
 
 ingredients:
-  dist: precise
+  dist: trusty
   sources: 
-    - deb http://us.archive.ubuntu.com/ubuntu/ precise main universe
+    - deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe
   ppas:
     - mank319/go-for-it
 

--- a/recipes/meta/Mumble.yml
+++ b/recipes/meta/Mumble.yml
@@ -2,9 +2,9 @@ app: Mumble
 union: true
 
 ingredients:
-  dist: precise
+  dist: trusty
   sources: 
-    - deb http://archive.ubuntu.com/ubuntu/ precise main universe
+    - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
   ppas:
     - mumble/snapshot
 

--- a/recipes/meta/PSPP.yml
+++ b/recipes/meta/PSPP.yml
@@ -2,9 +2,9 @@ app: PSPP
 union: true
 
 ingredients:
-  dist: precise
+  dist: trusty
   sources:
-    - deb http://archive.ubuntu.com/ubuntu/ precise main universe
+    - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
   ppas:
     - adamzammit/pspp
 

--- a/recipes/meta/QCTools.yml
+++ b/recipes/meta/QCTools.yml
@@ -2,11 +2,11 @@ app: QCTools
 binpatch: true
 
 ingredients:
-  dist: precise
+  dist: trusty
   packages:
     - qctools
     - libbz2-1.0
   sources:
-    - deb http://us.archive.ubuntu.com/ubuntu/ precise main universe
+    - deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe
   script:
     - wget https://mediaarea.net/download/binary/qctools/0.7.3/qctools_0.7.3-1_amd64.xUbuntu_12.04.deb

--- a/recipes/meta/Synergy.yml
+++ b/recipes/meta/Synergy.yml
@@ -2,9 +2,9 @@ app: Synergy
 binpatch: true
 
 ingredients:
-  dist: precise
+  dist: trusty
   sources:
-    - deb http://us.archive.ubuntu.com/ubuntu/ precise main universe
+    - deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe
   script:
     - DLD=$(wget -q "https://symless.com/nightly" -O - | grep "Linux-x86_64.deb" | grep v1 | head -n 1 | cut -d '"' -f 4)
     - wget -c "https://symless.com/$DLD"

--- a/recipes/meta/X2GoClient.yml
+++ b/recipes/meta/X2GoClient.yml
@@ -2,8 +2,8 @@ app: X2GoClient
 union: true
 
 ingredients:
-  dist: precise
+  dist: trusty
   sources:
-    - deb http://us.archive.ubuntu.com/ubuntu/ precise main universe 
+    - deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe 
   ppas:
     - x2go/stable

--- a/recipes/meta/XaraLX.yml
+++ b/recipes/meta/XaraLX.yml
@@ -6,9 +6,9 @@ ingredients:
     - xaralx
     - xaralx-examples
     - xaralx-svg 
-  dist: precise
+  dist: trusty
   sources: 
-    - deb http://us.archive.ubuntu.com/ubuntu/ precise main universe multiverse
+    - deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe multiverse
 
 script:
   - mkdir -p ./usr/share/icons/hicolor/48x48/apps

--- a/recipes/meta/XnViewMP.yml
+++ b/recipes/meta/XnViewMP.yml
@@ -23,7 +23,7 @@
 app: XnViewMP
 
 ingredients:
-  dist: precise
+  dist: trusty
   packages:
     - libasound2
     - libatk1.0-0
@@ -53,9 +53,9 @@ ingredients:
     - libxrender1
     - zlib1g
   sources:
-    - deb http://archive.ubuntu.com/ubuntu/ precise main restricted universe
-    - deb http://archive.ubuntu.com/ubuntu/ precise-updates main restricted universe
-    - deb http://archive.ubuntu.com/ubuntu/ precise-security main restricted universe
+    - deb http://archive.ubuntu.com/ubuntu/ trusty main restricted universe
+    - deb http://archive.ubuntu.com/ubuntu/ trusty-updates main restricted universe
+    - deb http://archive.ubuntu.com/ubuntu/ trusty-security main restricted universe
   script:
     - VERSION=$(wget -q -O- http://www.xnview.com/xnviewmp_update.txt | sed -n -e 's/^version=//p' | sed -e 's/\r//g')
     - wget -c http://download.xnview.com/old_versions/XnViewMP-$(echo $VERSION | tr -d '.')-linux-x64.tgz

--- a/recipes/meta/php5.6.yml
+++ b/recipes/meta/php5.6.yml
@@ -2,9 +2,9 @@ app: php5.6
 union: true
 
 ingredients:
-  dist: precise
+  dist: trusty
   sources:
-    - deb http://ftp.fau.de/ubuntu/ precise main universe
+    - deb http://ftp.fau.de/ubuntu/ trusty main universe
   ppas:
     - ondrej/php
   packages:

--- a/recipes/meta/php7.1.yml
+++ b/recipes/meta/php7.1.yml
@@ -2,9 +2,9 @@ app: php7.1
 union: true
 
 ingredients:
-  dist: precise
+  dist: trusty
   sources:
-    - deb http://ftp.fau.de/ubuntu/ precise main universe
+    - deb http://ftp.fau.de/ubuntu/ trusty main universe
   ppas:
     - ondrej/php
   packages:


### PR DESCRIPTION
According to https://wiki.ubuntu.com/Releases, precise is reaching íts end of life on April 28, 2017.
I figured we should move the AppImages now to make sure the AppImage builds work with trusty as well as with precise.