### PR TITLE
Improve removal of excluded files

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -84,11 +84,16 @@ delete_blacklisted()
   BLACKLISTED_FILES=$(cat_file_from_url https://github.com/probonopd/AppImages/raw/master/excludelist | sed 's|#.*||g')
   echo $BLACKLISTED_FILES
   for FILE in $BLACKLISTED_FILES ; do
-    FOUND=$(find . -xtype f -name "${FILE}" 2>/dev/null)
-    if [ ! -z "$FOUND" ] ; then
-      echo "Deleting blacklisted ${FOUND}"
-      rm -f "${FOUND}"
-    fi
+    FILES="$(find . -name "${FILE}")"
+    for FOUND in $FILES ; do
+      if [ -L "$FOUND" ] ; then
+        echo "Deleting blacklisted $FILE"
+        rm -f "$FOUND" "$(readlink -f "$FOUND")"
+      elif [ -f "$FOUND" ] ; then
+        echo "Deleting blacklisted $FILE"
+        rm -f "$FOUND"
+      fi
+    done
   done
 
   # Do not bundle developer stuff

--- a/functions.sh
+++ b/functions.sh
@@ -86,13 +86,7 @@ delete_blacklisted()
   for FILE in $BLACKLISTED_FILES ; do
     FILES="$(find . -name "${FILE}")"
     for FOUND in $FILES ; do
-      if [ -L "$FOUND" ] ; then
-        echo "Deleting blacklisted $FILE"
-        rm -f "$FOUND" "$(readlink -f "$FOUND")"
-      elif [ -f "$FOUND" ] ; then
-        echo "Deleting blacklisted $FILE"
-        rm -f "$FOUND"
-      fi
+      rm -vf "$FOUND" "$(readlink -f "$FOUND")"
     done
   done
 


### PR DESCRIPTION
Now if i.e. `libz.so.1` is on the list `libz.so.1.2.8` will be deleted too.

Works for me:
```
+ for FILE in '$BLACKLISTED_FILES'
++ find . -xtype f -regextype egrep -regex '^.*/libz.so.1($|[\.0-9]+$)'
+ FOUND='./lib/x86_64-linux-gnu/libz.so.1.2.8
./lib/x86_64-linux-gnu/libz.so.1'
+ for FILE in '$FOUND'
+ echo 'Deleting blacklisted ./lib/x86_64-linux-gnu/libz.so.1.2.8'
Deleting blacklisted ./lib/x86_64-linux-gnu/libz.so.1.2.8
+ rm -f ./lib/x86_64-linux-gnu/libz.so.1.2.8
+ for FILE in '$FOUND'
+ echo 'Deleting blacklisted ./lib/x86_64-linux-gnu/libz.so.1'
Deleting blacklisted ./lib/x86_64-linux-gnu/libz.so.1
+ rm -f ./lib/x86_64-linux-gnu/libz.so.1
```