### PR TITLE
Ignore blacklisted files in ./usr/optional/

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -84,7 +84,7 @@ delete_blacklisted()
   BLACKLISTED_FILES=$(cat_file_from_url https://github.com/AppImage/AppImages/raw/master/excludelist | sed 's|#.*||g')
   echo $BLACKLISTED_FILES
   for FILE in $BLACKLISTED_FILES ; do
-    FILES="$(find . -name "${FILE}")"
+    FILES="$(find . -name "${FILE}" -not -path "./usr/optional/*")"
     for FOUND in $FILES ; do
       rm -vf "$FOUND" "$(readlink -f "$FOUND")"
     done


### PR DESCRIPTION
This makes it easier to customize the AppImage according to https://github.com/AppImage/AppImageKit/wiki/Creating-AppImages#libstdcso6

Here's an example YAML file that would benefit from this:
``` yaml
app: Aegisub

ingredients:
  packages:
    #- aegisub-l10n  # localisation doesn't work
  dist: stable
  sources:
    - deb http://ftp.debian.org/debian/ stable main universe

script:
  - DEB=libstdc++6_6.3.0-18_amd64.deb
  - wget -O ../$DEB -c http://ftp.debian.org/debian/pool/main/g/gcc-6/$DEB
  - dpkg-deb -x ../$DEB .
  - mkdir -p ./usr/optional/libstdc++
  - mv ./usr/lib/x86_64-linux-gnu/libstdc++.so.6* ./usr/optional/libstdc++
  - find ./usr -name libstdc++.so.6*-gdb.py -delete
  - rm -rf ./AppRun ./usr/lib/x86_64-linux-gnu/x264-10bit
  - wget -O AppRun https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64
  - chmod a+x AppRun
```