### PR TITLE
fix for architecture on debian platform

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -34,6 +34,16 @@ case "$(uname -i)" in
 #  arm*)
 #    echo "ARM system architecture"
 #    SYSTEM_ARCH="";;
+  unknown)
+#         uname -i not answer on debian, then:
+    case "$(uname -m)" in
+      x86_64|amd64)
+#        echo "x86-64 system architecture"
+        SYSTEM_ARCH="x86_64";;
+      i?86)
+#        echo "x86 system architecture"
+        SYSTEM_ARCH="i686";;
+    esac ;;
   *)
     echo "Unsupported system architecture"
     exit 1;;


### PR DESCRIPTION
on debian, uname -i returns unknow, then use:  uname -m

as says [man uname](https://www.gnu.org/software/coreutils/manual/html_node/uname-invocation.html#uname-invocation), uname -i is not portable

on debian, on 32 or 64bits architecture,  I can't make an image.

I have fixed with this, and it work.

cordially
