### PR TITLE
Make docker image build succesfully if docker is invoked as root

### DIFF
--- a/recipes/meta/Dockerfile
+++ b/recipes/meta/Dockerfile
@@ -11,8 +11,11 @@ RUN sed -i 's/archive.ubuntu.com/ftp.fau.de/g' /etc/apt/sources.list && \
 
 ARG UID
 ARG GID
-RUN addgroup --gid $GID builder && \
-    adduser --uid $UID --gid $GID --disabled-login --disabled-password builder && \
+#The root user is already present; this causes adduser to fail if the image is built as root,
+#which is always the case if the docker client is invoked as root on the host
+#That's why the "|| true" is needed
+RUN addgroup --gid $GID builder || true && \
+    adduser --uid $UID --gid $GID --disabled-login --disabled-password builder || true && \
     chown $UID.$GID /workspace
 
 USER $UID


### PR DESCRIPTION
`adduser` and `addgroup` fail if the `UID` or `GID` is already in use, which is the case if the docker client is invoked as `root`, which causes the image to fail to build.