### PR TITLE
recipes/meta: fix meshmixer.desktop

### DIFF
--- a/recipes/meta/Meshmixer.yml
+++ b/recipes/meta/Meshmixer.yml
@@ -28,6 +28,7 @@ script:
   - mv ./usr/lib/libblas/*.so* ./usr/lib/
   - ( cd usr/lib/ ; ln -s libblas.so.3 libblas.so.3gf )
   - ( cd usr/lib/ ; ln -s liblapack.so.3 liblapack.so.3gf )
-  - sed -i -e 's|^Version=.*|Version=1.0|g' meshmixer.desktop # Dear upstream developers, see https://github.com/AppImage/AppImages/issues/166
+  - sed -i -e '/^Version=.*/d' meshmixer.desktop # Dear upstream developers, see https://github.com/AppImage/AppImages/issues/166
   - sed -i -e 's|^Comment=.*|Comment=The ultimate tool for 3D mashups and remixes|g' meshmixer.desktop # Dear upstream developers, see https://github.com/AppImage/AppImages/issues/166
+  - sed -i -e '/^Action Bar/d' meshmixer.desktop # Dear upstream developers, see https://github.com/AppImage/AppImages/issues/166
   - cp usr/share/pixmaps/meshmixer.png usr/share/icons/hicolor/128x128/apps # So that desktopintegration has something to work with


### PR DESCRIPTION
@probonopd Please take a look.

I had a sed expression that handled the double line, working on my other workstation, but not here, so I've just brutally trimmed the text.

Fixes #166.