### PR TITLE
Allow overriding of appimagetool parameters

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -181,6 +181,10 @@ generate_appimage()
 }
 
 # Generate AppImage type 2
+# Additional parameters given to this routine will be passed on to appimagetool
+#
+# If the environment variable NO_GLIBC_VERSION is set, the required glibc version
+# will not be added to the AppImage filename
 generate_type2_appimage()
 {
   # Get the ID of the last successful build on Travis CI
@@ -208,6 +212,12 @@ generate_type2_appimage()
     trap _appimagetool_cleanup EXIT
   fi
 
+  if [ -z ${NO_GLIBC_VERSION+true} ]; then
+    VERSION_EXPANDED=$VERSION.glibc$GLIBC_NEEDED
+  else
+    VERSION_EXPANDED=$VERSION
+  fi
+
   set +x
   if ( [ ! -z "$KEY" ] ) && ( ! -z "$TRAVIS" ) ; then
     wget https://github.com/AppImage/AppImageKit/files/584665/data.zip -O data.tar.gz.gpg
@@ -216,10 +226,10 @@ generate_type2_appimage()
     sudo chown -R $USER .gnu*
     mv $HOME/.gnu* $HOME/.gnu_old ; mv .gnu* $HOME/
     GLIBC_NEEDED=${GLIBC_NEEDED:=$(glibc_needed)}
-    VERSION=$VERSION.glibc$GLIBC_NEEDED "$appimagetool" -n -s --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
+    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n -s --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
   else
     GLIBC_NEEDED=${GLIBC_NEEDED:=$(glibc_needed)}
-    VERSION=$VERSION.glibc$GLIBC_NEEDED "$appimagetool" -n --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
+    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
   fi
   set -x
   mkdir -p ../out/ || true


### PR DESCRIPTION
This PR resolves #549.

This patch allows you to add arbitrary parameters to `generate_type2_appimage` which will be passed on to `appimagetool`.

I also added a feature that you can set the environment variable `NO_GLIBC_VERSION` to create AppImages without the glibc version in the filename.