### PR TITLE
fail to -m for AuthenticAMD

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -34,7 +34,7 @@ case "$(uname -i)" in
 #  arm*)
 #    echo "ARM system architecture"
 #    SYSTEM_ARCH="";;
-  unknown)
+  unknown|AuthenticAMD)
 #         uname -i not answer on debian, then:
     case "$(uname -m)" in
       x86_64|amd64)


### PR DESCRIPTION
On my AMD FX6300 workstation:

    $ uname -i
    AuthenticAMD

This causes functions.sh to fail with ``unsupported``.

