### PR TITLE
Add post_script section to ingrediants

### DIFF
--- a/pkg2appimage
+++ b/pkg2appimage
@@ -242,6 +242,11 @@ if [ ! -z "${_ingredients_dist}" ] ; then
   $dltool -c -i- <<<"$URLS"
 fi
 
+if [ ! -z "${_ingredients_post_script[0]}" ] ; then
+  # Execute extra steps defined in recipe
+  shell_execute $YAMLFILE _ingredients_post_script
+fi
+
 mkdir -p ./$APP.AppDir/
 cd ./$APP.AppDir/
 

--- a/recipes/FreeCAD-asm3.yml
+++ b/recipes/FreeCAD-asm3.yml
@@ -1,0 +1,54 @@
+app: FreeCAD-asm3
+binpatch: true
+
+ingredients:
+  dist: trusty
+  sources: 
+    - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
+  ppas:
+    - freecad-maintainers/freecad-daily
+  packages:
+    - freecad-daily
+    # - calculix-ccx
+    - appmenu-qt
+  pretend:
+    - libfontconfig1 2.11.0-0ubuntu4
+  script:
+    - rm -f freecad-daily*amd64.deb
+    # try to restore the original package to prevent repeated download
+    - ! test -f tmp/freecad-daily*.deb || mv tmp/freecad-daily*.deb .
+  post_script:
+    - mkdir -p tmp
+    # save the original package for future redo
+    - mv freecad-daily*.deb tmp/
+    # replace the freecad deb package with our custom build
+    - cp $HOME/pbuilder/trusty_result/freecad-daily*amd64.deb .
+
+script:
+  # install asm3
+  - dir=$PWD
+  - cd ./usr/lib/freecad-daily/Ext/freecad
+  - rm -rf asm3
+  - git clone https://github.com/realthunder/FreeCAD_assembly3.git asm3 
+  - cd asm3
+  - git submodule update --init py_slvs
+  # generate version as asm3-<asm3 last commit hash>-<last commit date>
+  - gitdate=`date -d "$(git show -s --format=%aI)" +%Y%m%d%H%M`
+  - debdate=`date -r $dir/../freecad-daily*.deb +%Y%m%d%H%M`
+  - [ $debdate -lt $gitdate ] || gitdate=$debdate
+  - echo "asm3-$(git show -s --format=%h)-$gitdate" > $dir/../VERSION
+  - rm -rf `find -name '.git*'`
+  - cd $dir
+  # resume setup just like FreeCAD-nightly
+  - cp ./usr/share/applications/freecad-daily.desktop .
+  - ln -s freecad-daily.desktop freecad-asm3.desktop
+  - sed -i -e 's@FreeCAD Daily@FreeCAD@g' freecad-daily.desktop
+  - sed -i -e 's@/usr/bin/@@g' freecad-daily.desktop
+  - sed -i -e 's@Path=@# Path=@g' freecad-daily.desktop
+  # - sed -i -e 's@Icon=freecad@Icon=freecad-daily@g' freecad-daily.desktop
+  - cp ./usr/share/icons/hicolor/64x64/apps/freecad-daily.png .
+  - # Dear upstream developers, please use relative rather than absolute paths
+  - # then binary patching like this will become unneccessary
+  - find usr/ -type f -exec sed -i -e "s@/usr/lib/freecad-daily@././/lib/freecad-daily@g" {} \;
+  - find usr/ -type f -exec sed -i -e "s@/usr/share/freecad-daily@././/share/freecad-daily@g" {} \;
+  - ( cd ./usr/lib/freecad-daily/ ; ln -s ../../share/ . ) # Why?


### PR DESCRIPTION
post_script gives the recipe a chance to modify the downloaded packages from ingredient before installation.

One common use case is for a user to build an AppImage based on a custom-built package from the official source. The recipe can rely on apt to pull dependency from the official source. Once all packages are downloaded, the recipe can use post_script to replace the official package with the custom-built one.

An example recipe FreeCAD-asm3 is included.