### PR TITLE
Move lapack and libblas to the correct path

### DIFF
--- a/recipes/FreeCAD-nightly.yml
+++ b/recipes/FreeCAD-nightly.yml
@@ -23,6 +23,8 @@ script:
   - sed -i -e 's@Path=@# Path=@g' freecad-daily.desktop
   # - sed -i -e 's@Icon=freecad@Icon=freecad-daily@g' freecad-daily.desktop
   - cp ./usr/share/icons/hicolor/64x64/apps/freecad-daily.png .
+  - mv ./usr/lib/lapack/*.so* ./usr/lib/
+  - mv ./usr/lib/libblas/*.so* ./usr/lib/
   - # Dear upstream developers, please use relative rather than absolute paths
   - # then binary patching like this will become unneccessary
   - find usr/ -type f -exec sed -i -e "s@/usr/lib/freecad-daily@././/lib/freecad-daily@g" {} \;


### PR DESCRIPTION
Lapack and libblas is not in the correct path for Numpy to find them.
See discussion here: https://forum.freecadweb.org/viewtopic.php?f=4&t=25942

This solution is borrowed from the Octave.yml Receipe.
https://github.com/AppImage/AppImages/blob/master/recipes/Octave.yml

Is this the preferred solution to this problem from AppImage perspective or do you recommend something else?