### PR TITLE
Fix unsupported platform on GenuineIntel

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -41,7 +41,7 @@ case "$(uname -i)" in
 #  arm*)
 #    echo "ARM system architecture"
 #    SYSTEM_ARCH="";;
-  unknown|AuthenticAMD)
+  unknown|AuthenticAMD|GenuineIntel)
 #         uname -i not answer on debian, then:
     case "$(uname -m)" in
       x86_64|amd64)


### PR DESCRIPTION
``GenuineIntel`` is also an indicator that ``uname -i`` doesn't return the desired result.