### PR TITLE
Add Matplotlib package

### DIFF
--- a/recipes/FreeCAD-nightly.yml
+++ b/recipes/FreeCAD-nightly.yml
@@ -9,6 +9,7 @@ ingredients:
     - freecad-maintainers/freecad-daily
   packages:
     - freecad-daily
+    - python-matplotlib
     # - calculix-ccx
     - appmenu-qt
   pretend:


### PR DESCRIPTION
Add Matplotlib package to FreeCAD daily AppImage. Some FreeCAD modules depend on it and the size addition is small.

https://forum.freecadweb.org/viewtopic.php?f=22&t=27013