### PR TITLE
Enable Matplotlib package

### DIFF
--- a/recipes/FreeCAD-nightly.yml
+++ b/recipes/FreeCAD-nightly.yml
@@ -10,6 +10,7 @@ ingredients:
   packages:
     - freecad-daily
     - python-tk
+    - python-scipy
     # - calculix-ccx
     - appmenu-qt
   pretend:

--- a/recipes/FreeCAD-nightly.yml
+++ b/recipes/FreeCAD-nightly.yml
@@ -9,7 +9,7 @@ ingredients:
     - freecad-maintainers/freecad-daily
   packages:
     - freecad-daily
-    - python-matplotlib
+    - python-tk
     # - calculix-ccx
     - appmenu-qt
   pretend:
@@ -26,6 +26,15 @@ script:
   - cp ./usr/share/icons/hicolor/64x64/apps/freecad-daily.png .
   - mv ./usr/lib/lapack/*.so* ./usr/lib/
   - mv ./usr/lib/libblas/*.so* ./usr/lib/
+  - # Matplotlib start (not needed anymore on Ubuntu 16.04)
+  - mv ./usr/share/pyshared/matplotlib* ./usr/lib/python2.7/dist-packages/
+  - mv ./usr/share/pyshared/mpl_toolkits ./usr/lib/python2.7/dist-packages/
+  - mv ./usr/share/pyshared/pylab.py ./usr/lib/python2.7/dist-packages/
+  - touch ./usr/lib/python2.7/dist-packages/matplotlib/compat/__init__.py
+  - mv ./usr/lib/pyshared/python2.7/matplotlib/backends/*.so ./usr/lib/python2.7/dist-packages/matplotlib/backends/
+  - mv ./usr/lib/pyshared/python2.7/matplotlib/*.so ./usr/lib/python2.7/dist-packages/matplotlib/
+  - rm -rf ./usr/lib/pyshared/python2.7/matplotlib/
+  - # Matplotlib end
   - # Dear upstream developers, please use relative rather than absolute paths
   - # then binary patching like this will become unneccessary
   - find usr/ -type f -exec sed -i -e "s@/usr/lib/freecad-daily@././/lib/freecad-daily@g" {} \;


### PR DESCRIPTION
+ Enable Matplotlib package
+ Additional python-tk package for Animation workbench

In last attempt i was too quick and didn't realize matplotlib package is already included but not used in AppImage. Proposed changes in this PR should enable the matplotlib package to be used after.

Related:
https://github.com/AppImage/AppImages/pull/316

Edit: For correctness and to reduce any potential possible future confusion.  Additional python-tk package was added due to Animation and not Plot workbench depending on it. I edited the initial description.

https://forum.freecadweb.org/viewtopic.php?f=22&t=27013&p=217633#p217633