### PR TITLE
Change icon name Firefox.yml

### DIFF
--- a/recipes/Firefox.yml
+++ b/recipes/Firefox.yml
@@ -13,7 +13,7 @@ ingredients:
 
 script:
   - cp -r ../firefox/* usr/bin/
-  - find . -name mozicon128.png -exec cp {} firefox.png \;
+  - find . -name default128.png -exec cp {} firefox.png \;
   - # Workaround for:
   - # https://bugzilla.mozilla.org/show_bug.cgi?id=296568
   - cat > firefox.desktop <<EOF

--- a/recipes/Firefox.yml
+++ b/recipes/Firefox.yml
@@ -13,6 +13,7 @@ ingredients:
 
 script:
   - cp -r ../firefox/* usr/bin/
+  - find . -name mozicon128.png -exec cp {} firefox.png \;
   - find . -name default128.png -exec cp {} firefox.png \;
   - # Workaround for:
   - # https://bugzilla.mozilla.org/show_bug.cgi?id=296568


### PR DESCRIPTION
The icon name filename has changed from mozicon128 to default128 in 59.0.1