### PR TITLE
Fix the boostnote recipe, wasn't able to fetch the URL of the .deb file 

### DIFF
--- a/recipes/Boostnote.yml
+++ b/recipes/Boostnote.yml
@@ -5,7 +5,7 @@ ingredients:
   sources: 
     - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
   script:
-    - URL=$(wget -q https://boostnote.io/ -O - | grep -e "boostnote_.*_amd64.deb" | cut -d '"' -f 2)
+    - URL=$(wget -q https://boostnote.io/ -O - | grep -e "boostnote_.*_amd64.deb" | cut -d '"' -f 4)
     - wget -c "$URL"
     - echo "$URL" | cut -d _ -f 2 > VERSION
   exclude:


### PR DESCRIPTION
The script could't find the .deb url, corrected the bug