### PR TITLE
No longer bundle libharfbuzz and libfreetype

### DIFF
--- a/excludelist
+++ b/excludelist
@@ -82,6 +82,12 @@ libfontconfig.so.1
 # Workaround for:
 # Application stalls when loading fonts during application launch; e.g., KiCad on ubuntu-mate
 
+# other "low-level" font rendering libraries
+# should fix https://github.com/probonopd/linuxdeployqt/issues/261#issuecomment-377522251
+# and https://github.com/probonopd/linuxdeployqt/issues/157#issuecomment-320755694
+libfreetype.so.6
+libharfbuzz.so.0
+
 # Note, after discussion we do not exlude this, but we can use a dummy library that just does nothing
 # libselinux.so.1
 # Workaround for:


### PR DESCRIPTION
Those seem to cause major problems on systems with never versions of libfontconfig (such as Fedora, and recently Arch and their derivatives). As they're most likely not direct dependencies, not bundling them shouldn't break anything.

CC @probonopd