### PR TITLE
Exclude: libfontconfig1-dev

### DIFF
--- a/recipes/FreeCAD-nightly.yml
+++ b/recipes/FreeCAD-nightly.yml
@@ -13,8 +13,8 @@ ingredients:
     - python-scipy
     # - calculix-ccx
     - appmenu-qt
-  pretend:
-    - libfontconfig1 2.11.0-0ubuntu4
+  exclude:
+    - libfontconfig1-dev
 
 script:
   - ls ../freecad-daily*.deb | cut -d "_" -f 2 | cut -d "~" -f 1-2 | sed -e 's|~.*+git|.git|g' > ../VERSION


### PR DESCRIPTION
I was just about to create FreeCAD related PR. To remove FreeType from the FreeCAD recipe and have seen this:

https://github.com/AppImage/AppImages/pull/323

I can confirm we where affected by the mentioned issue too. In addition we use libfontconfig1-dev package as a workaround on PPA (for not having to create a symlink). I guess it is harmless if it is added to the AppImage. But as it doesn't do anything from the AppImage perspective. Likely best to remove it altogether.

https://forum.freecadweb.org/viewtopic.php?f=10&t=15525&start=190#p222348