### PR TITLE
Exclude libgomp1

### DIFF
--- a/recipes/FreeCAD-0.16.yml
+++ b/recipes/FreeCAD-0.16.yml
@@ -17,6 +17,9 @@ ingredients:
     - appmenu-qt
   exclude:
     - libfontconfig1-dev
+    - # Use the system provided version of libgomp
+    - # Version provided in Trusty does not work with new versions of CalculiX
+    - libgomp1
 
 script:
   - ls ../freecad-0.16*.deb | cut -d "." -f 6 | cut -d "-" -f 1 > ../VERSION

--- a/recipes/FreeCAD-Daily.yml
+++ b/recipes/FreeCAD-Daily.yml
@@ -15,6 +15,9 @@ ingredients:
     - appmenu-qt
   exclude:
     - libfontconfig1-dev
+    - # Use the system provided version of libgomp
+    - # Version provided in Trusty does not work with new versions of CalculiX
+    - libgomp1
 
 script:
   - ls ../freecad-daily*.deb | cut -d "_" -f 2 | cut -d "~" -f 1-2 | sed -e 's|~.*+git|.git|g' > ../VERSION

--- a/recipes/FreeCAD.yml
+++ b/recipes/FreeCAD.yml
@@ -15,6 +15,9 @@ ingredients:
     - appmenu-qt
   exclude:
     - libfontconfig1-dev
+    - # Use the system provided version of libgomp
+    - # Version provided in Trusty does not work with new versions of CalculiX
+    - libgomp1
 
 script:
   - ls ../freecad*.deb | cut -d "." -f 5 | cut -d "-" -f 1 > ../VERSION


### PR DESCRIPTION
We don't pack CalculiX in FreeCAD AppImage. Newer versions of CalculiX don't work with older version of libgomp1 provided by Trusty. AFAIK we don't use libgomp1 anywhere in FreeCAD ATM. Therefore the easiest fix for now is not to include libgomp1 in AppImage and let CalculiX use the system default version.

Reference:
https://forum.freecadweb.org/viewtopic.php?f=3&t=28519