### PR TITLE
Fix Solus OS dependency

### DIFF
--- a/excludedeblist
+++ b/excludedeblist
@@ -49,7 +49,7 @@ libgl1-mesa
 libgl1-mesa-dri
 libgl1-mesa-glx
 # libglib2.0-0 # https://github.com/LibreCAD/LibreCAD/issues/858#issuecomment-345449318
-libglu1-mesa
+# libglu1-mesa #
 # libgnutls26 cannot be expected to be eveywhere, e.g., KDE neon
 # libgpg-error0 gives non-fatal errors on many systems and is low-level, can it be expected to be everywhere?
 libgpg-error0

--- a/excludelist
+++ b/excludelist
@@ -130,7 +130,7 @@ libgpg-error.so.0
 libICE.so.6
 # libidn.so.11 # Does not come with Solus by default
 # libk5crypto.so.3 # Runnning AppImage built on Debian 9 or Ubuntu 16.04 on an Archlinux fails otherwise; https://github.com/AppImage/AppImages/issues/301
-libkeyutils.so.1
+# libkeyutils.so.1 #
 # libkrb5.so.26 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there. Missing on openSUSE LEAP 42.0
 # libkrb5.so.3 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
 # libkrb5support.so.0 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there


### PR DESCRIPTION
[ONLYOFFICE DesktopEditor AppImage](https://github.com/ONLYOFFICE/appimage-desktopeditors)  fails on Solus OS because there are omitted dependency:

- libkeyutils.so.1
- libGLU.so.1

These libraries don't include into AppImage because `libkeyutils.so.1` is in `excludelist` and `libglu1-mesa` (`libGLU.so.1` library) is in `excludedeblist`.