### PR TITLE
* use the newest inkscape@0.92.3 version on stable channel

### DIFF
--- a/recipes/Inkscape.yml
+++ b/recipes/Inkscape.yml
@@ -7,7 +7,7 @@ ingredients:
     - python-lxml
     - python-numpy
     - python-scour
-  dist: bionic
+  dist: trusty
   sources:
     # - deb http://mirrors.aliyun.com/ubuntu/ bionic main universe
     - deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe

--- a/recipes/Inkscape.yml
+++ b/recipes/Inkscape.yml
@@ -9,7 +9,7 @@ ingredients:
     - python-scour
   dist: trusty
   sources:
-    # - deb http://mirrors.aliyun.com/ubuntu/ bionic main universe
+    # - deb http://mirrors.aliyun.com/ubuntu/ trusty main universe
     - deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe
   ppas:
     - inkscape.dev/stable
@@ -17,4 +17,4 @@ ingredients:
 script:
   - sed -i -e 's|Drawing Shortcut Group|X-Drawing Shortcut Group|g' inkscape.desktop
   - ls ../inkscape_*.deb | cut -d "_" -f 2 | cut -d "~" -f 1 | head -n 1 > ../VERSION
-  #- rm usr/lib/x86_64-linux-gnu/libharfbuzz.so.* # Workaround for Fedora 25, symbol lookup error: /lib64/libpangoft2-1.0.so.0: undefined symbol: hb_buffer_set_cluster_level
+  # - rm usr/lib/x86_64-linux-gnu/libharfbuzz.so.* # No SUch file now. Workaround for Fedora 25, symbol lookup error: /lib64/libpangoft2-1.0.so.0: undefined symbol: hb_buffer_set_cluster_level

--- a/recipes/Inkscape.yml
+++ b/recipes/Inkscape.yml
@@ -2,14 +2,19 @@ app: Inkscape
 binpatch: true # With union: true, getting: Units file /usr/share/inkscape/ui/units.xml is missing
 
 ingredients:
-  package: inkscape-trunk
-  dist: trusty
-  sources: 
+  packages:
+    - inkscape
+    - python-lxml
+    - python-numpy
+    - python-scour
+  dist: bionic
+  sources:
+    # - deb http://mirrors.aliyun.com/ubuntu/ bionic main universe
     - deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe
   ppas:
-    - inkscape.dev/trunk
+    - inkscape.dev/stable
 
 script:
   - sed -i -e 's|Drawing Shortcut Group|X-Drawing Shortcut Group|g' inkscape.desktop
-  - ls ../inkscape-trunk_*.deb | cut -d "_" -f 2 | cut -d "~" -f 1 | head -n 1 > ../VERSION
-  - rm usr/lib/x86_64-linux-gnu/libharfbuzz.so.* # Workaround for Fedora 25, symbol lookup error: /lib64/libpangoft2-1.0.so.0: undefined symbol: hb_buffer_set_cluster_level
+  - ls ../inkscape_*.deb | cut -d "_" -f 2 | cut -d "~" -f 1 | head -n 1 > ../VERSION
+  #- rm usr/lib/x86_64-linux-gnu/libharfbuzz.so.* # Workaround for Fedora 25, symbol lookup error: /lib64/libpangoft2-1.0.so.0: undefined symbol: hb_buffer_set_cluster_level


### PR DESCRIPTION
* The inkscape's dev channel has already been deprecated.
* [bug] fixed inkscape@0.92.3 missing python package

restore dist to trust.