### PR TITLE
Add out directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # Backup & Temporary files
 *~
+
+# Build images
+out/


### PR DESCRIPTION
This commit adds `out/` to .gitignore. The directory is used for
storing AppImages by pkg2appimage execution. So, let's ignore the
files because we don't need to manage them.