### PR TITLE
Add rhel based system compatibility

### DIFF
--- a/pkg2appimage
+++ b/pkg2appimage
@@ -247,7 +247,7 @@ if [ ! -z "${_ingredients_dist}" ] ; then
   fi
 
   apt-get -o Acquire::AllowInsecureRepositories=true -o Acquire::Languages="none" -o Acquire::AllowDowngradeToInsecureRepositories=true $OPTIONS update || true
-  URLS=$(apt-get --allow-unauthenticated -o Apt::Get::AllowUnauthenticated=true $OPTIONS -y install --print-uris $INSTALL | cut -d "'" -f 2 | grep -e "^http")
+  URLS=$(apt-get --allow-unauthenticated -o Apt::Get::AllowUnauthenticated=true $OPTIONS -y install --print-uris $INSTALL | cut -d "'" -f 2 | grep -e "^http") || true
   if which aria2c &>/dev/null; then
     dltool=aria2c
   else


### PR DESCRIPTION
Quick fix awaiting more elaborate modification that check dnf/urpmi instead of apt-get ...
i did not do it because packages names differ from debian to rhel based system like libgconf to lib64gconf so it will be some how complicated to have full compatibility to rhel but at least this quick fix make it work ;) needed packages for this or that yml will need manual install