### PR TITLE
Do not exclude libnsl.so.1

### DIFF
--- a/excludelist
+++ b/excludelist
@@ -15,7 +15,7 @@ libc.so.6
 libdl.so.2
 libm.so.6
 libmvec.so.1
-libnsl.so.1
+# libnsl.so.1 # Not part of glibc anymore as of Fedora 28. See https://github.com/RPCS3/rpcs3/issues/5224#issuecomment-434930594
 libnss_compat.so.2
 libnss_db.so.2
 libnss_dns.so.2


### PR DESCRIPTION
libnsl.so.1 is not part of glibc anymore as of Fedora 28.
Let's this to find out whether this causes any trouble. 

According to https://github.com/RPCS3/rpcs3/issues/5224#issuecomment-434930594 it should be fine. 

Will have to revert this in case it causes trouble